### PR TITLE
Fix loading null tab contents

### DIFF
--- a/site/public/index.html
+++ b/site/public/index.html
@@ -50,19 +50,19 @@
           <ul>
             <li class="tab-item is-active" data-tab-id='secret'>
               <a>
-                <span class="icon is-small"><i class="fa fa-user-secret"></i></span>
+                <span class="icon is-small" data-tab-id='secret'><i class="fa fa-user-secret"></i></span>
                 Get Secret
               </a>
             </li>
             <li class="tab-item" data-tab-id='token'>
               <a>
-                <span class="icon is-small"><i class="fa fa-key"></i></span>
+                <span class="icon is-small" data-tab-id='token'><i class="fa fa-key"></i></span>
                 Get Token
               </a>
             </li>
             <li class="tab-item" data-tab-id='verify'>
               <a>
-                <span class="icon is-small"><i class="fa fa-eye"></i></span>
+                <span class="icon is-small" data-tab-id='verify'><i class="fa fa-eye"></i></span>
                 Verify
               </a>
             </li>


### PR DESCRIPTION
This fixes #20 on my machine, (didn't try it with the online version. tbh)
To debug I just added that line of code and saw that it's `null`. I'm no web pro so that's why I'm detailing the solution so you know if I did something wrong.

`public/app.js`

```javascript
  var tabClass = parent.getAttribute('data-tab-id');
  console.log('Clicked:' + tabClass);   // Prints `undefined` if you click on icon (without the fix)
```